### PR TITLE
Fix concat of image arrays

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -120,7 +120,9 @@ async function attemptPlace() {
     }
 
     const rgbaOrder = currentOrders.data;
-    const rgbaCanvas = [].concat(map0.data, map1.data);
+    const rgbaCanvas = new Uint8Array(map0.data.length + map1.data.length);
+    rgbaCanvas.set(map0.data);
+    rgbaCanvas.set(map1.data, map0.data.length);
 
     for (const i of order) {
         // negeer lege order pixels.


### PR DESCRIPTION
UInt8Arrays do not concat properly, rgbaCanvas currently has 2 elements. Leads to the script always replacing the first pixel it checks as the Hex colour comes out as '#AN'  
https://github.com/scijs/get-pixels/blob/master/node-pixels.js#L22
https://stackoverflow.com/questions/49129643/how-do-i-merge-an-array-of-uint8arrays

Below from debugging with some additional console.logs

```
const rgbaCanvas = [].concat(map0.data, map1.data);
console.log(rgbaCanvas);

...


        // Deze pixel klopt.
		const targetHex = rgbToHex(rgbaCanvas[pixelLocation], rgbaCanvas[pixelLocation + 1], rgbaCanvas[pixelLocation + 2]);
	console.log(`Comparing ${hex}, ${targetHex} ${rgbaCanvas[pixelLocation]}, ${rgbaCanvas[pixelLocation + 1]}, ${rgbaCanvas[pixelLocation + 2]}`)
        if (hex === targetHex) continue;
```
![image](https://user-images.githubusercontent.com/13240044/161419732-daf0503f-6679-49a7-91dd-ac95f983ab00.png)
